### PR TITLE
Export all types

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,6 @@
 export * from './hooks/juice-contracts/read';
 export * from './hooks/juice-contracts/write';
 export * from './hooks/juice-contracts/contracts';
+export * from './types';
 
 export { JuiceProvider } from './contexts/JuiceContext';

--- a/packages/react/src/types/contractReadHookResponse.ts
+++ b/packages/react/src/types/contractReadHookResponse.ts
@@ -1,0 +1,5 @@
+export interface ContractReadHookResponse<T> {
+  data: T | undefined;
+  loading: boolean;
+  error: Error | undefined;
+}

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -1,7 +1,4 @@
-export interface ContractReadHookResponse<T> {
-  data: T | undefined;
-  loading: boolean;
-  error: Error | undefined;
-}
-
-export type ProjectId = number;
+export * from './contractReadHookResponse';
+export * from './fundingCycle';
+export * from './projectId';
+export * from './splits';

--- a/packages/react/src/types/projectId.ts
+++ b/packages/react/src/types/projectId.ts
@@ -1,0 +1,1 @@
+export type ProjectId = number;


### PR DESCRIPTION
Exports the types explicitly from package root.

Also reshuffles some of the type stuff into separate files with a concise index
